### PR TITLE
Installation instructions + support for Laravel 5.7 - 6.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravelcollective/errors",
+    "name": "jhnbrn90/laravel-errors",
     "description": "Error pages for the Laravel Framework",
     "license": "MIT",
     "homepage": "https://laravelcollective.com",
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "laravel/framework": "^6.0"
+        "laravel/framework": "5.7 - 6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jhnbrn90/laravel-errors",
+    "name": "laravelcollective/errors",
     "description": "Error pages for the Laravel Framework",
     "license": "MIT",
     "homepage": "https://laravelcollective.com",

--- a/readme.md
+++ b/readme.md
@@ -6,3 +6,15 @@
 [![License](https://poser.pugx.org/LaravelCollective/errors/license.svg)](https://packagist.org/packages/laravelcollective/errors)
 
 Official documentation for Errors for The Laravel Framework can be found at the [LaravelCollective](http://laravelcollective.com) website.
+
+## Installation
+You can install the package via composer:
+```
+composer require laravelcollective/errors
+```
+Publish the error views and svgs:
+```
+php artisan vendor:publish --provider="Collective\Errors\ErrorsServiceProvider" --tag="laravel-collective-errors"
+```
+
+That's it, enjoy your beautiful error pages!


### PR DESCRIPTION
As I've mentioned in #7, the package now requires Laravel versions 6 and higher, while it perfectly supports Laravel installations with versions ranging from 5.7 to 6.0. This PR updated the `composer.json` to allow exactly this range.

Additionally, I've updated the Readme to include instructions how to publish the assets of this package.